### PR TITLE
Restore and update tests

### DIFF
--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -219,16 +219,16 @@ impl fmt::Display for Metrics {
 /// update an in-memory accumulator which is later persisted for billing.
 ///
 /// ### Example:
-/// ```rust
+/// ```rust,no_run
 /// use artisan_middleware::aggregator::LiveMetrics;
-/// LiveMetrics {
+/// let _metrics = LiveMetrics {
 ///     runner_id: "abc123".into(),
 ///     instance_id: "xyz456".into(),
-///     cpu_percent: 12.5,
+///     cpu_usage: 12.5,
 ///     memory_mb: 256.0,
 ///     rx_bytes: 15000,
 ///     tx_bytes: 5000,
-/// }
+/// };
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LiveMetrics {

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -47,7 +47,7 @@ static ref initialized:  Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 ///
 /// # Example
 /// ```rust
-/// # use dusa_collection_utils::types::stringy::Stringy;
+/// # use dusa_collection_utils::core::types::stringy::Stringy;
 /// # use tokio::runtime::Runtime;
 /// # use std::time::Duration;
 /// # use artisan_middleware::encryption::encrypt_text;
@@ -92,7 +92,7 @@ pub async fn encrypt_text(data: Stringy) -> Result<Stringy, ErrorArrayItem> {
 ///
 /// # Example
 /// ```rust
-/// # use dusa_collection_utils::types::stringy::Stringy;
+/// # use dusa_collection_utils::core::types::stringy::Stringy;
 /// # use tokio::runtime::Runtime;
 /// # use std::time::Duration;
 /// # use artisan_middleware::encryption::decrypt_text;

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -356,7 +356,7 @@ impl Identifier {
     /// # Example
     /// ```rust
     /// # use artisan_middleware::identity::Identifier;
-    /// # use dusa_collection_utils::types::stringy::Stringy;
+    /// # use dusa_collection_utils::core::types::stringy::Stringy;
     /// # use tokio::runtime::Runtime;
     /// let rt = Runtime::new().unwrap();
     /// rt.block_on(async {
@@ -373,7 +373,7 @@ impl Identifier {
     /// # Example
     /// ```rust
     /// # use artisan_middleware::identity::Identifier;
-    /// # use dusa_collection_utils::types::stringy::Stringy;
+    /// # use dusa_collection_utils::core::types::stringy::Stringy;
     /// # use tokio::runtime::Runtime;
     /// let rt = Runtime::new().unwrap();
     /// rt.block_on(async {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,29 +33,27 @@ pub mod version;
 pub const RELEASEINFO: VersionCode = VersionCode::Beta;
 
 // // tests
-// #[path = "../src/tests/encryption_test.rs"]
-// mod encryption_test;
-
-// #[path = "../src/tests/identity_test.rs"]
-// mod identity_test;
-
 #[path = "../src/tests/process_manager.rs"]
 mod process_manager_test;
+#[path = "../src/tests/encryption.rs"]
+mod encryption_test;
 
-// #[path = "../src/tests/notification_test.rs"]
-// mod notification_test;
+#[path = "../src/tests/identity.rs"]
+mod identity_test;
 
-// #[path = "../src/tests/state_persistence_test.rs"]
-// mod state_persistence_test;
+#[path = "../src/tests/git_action.rs"]
+mod git_action_test;
 
-// #[path = "../src/tests/resource_monitor_test.rs"]
-// mod resource_monitor_test;
+#[path = "../src/tests/notification.rs"]
+mod notification_test;
 
-// #[path = "../src/tests/git_action_tests.rs"]
-// mod git_action_tests;
+#[path = "../src/tests/state_persistence.rs"]
+mod state_persistence_test;
 
-// #[path = "../src/tests/socket_communication.rs"]
-// mod socket_communication_test;
+#[cfg(target_os = "linux")]
+#[path = "../src/tests/resource_monitor.rs"]
+mod resource_monitor_test;
 
-// #[path = "../src/tests/network_communication_test.rs"]
-// mod network_communication_test;
+#[cfg(target_os = "linux")]
+#[path = "../src/tests/network.rs"]
+mod network_test;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -59,7 +59,7 @@ impl Email {
     ///
     /// # Example
     /// ```rust
-    /// # use dusa_collection_utils::types::stringy::Stringy;
+    /// # use dusa_collection_utils::core::types::stringy::Stringy;
     /// # use artisan_middleware::notifications::Email;
     /// let subject = Stringy::from("Greetings");
     /// let body = Stringy::from("Hello, how are you?");
@@ -151,7 +151,7 @@ impl Email {
     /// # Example
     /// ```rust
     /// # use tokio::runtime::Runtime;
-    /// # use dusa_collection_utils::types::stringy::Stringy;
+    /// # use dusa_collection_utils::core::types::stringy::Stringy;
     /// # use artisan_middleware::notifications::Email;
     /// # let rt = Runtime::new().unwrap();
     /// # rt.block_on(async {

--- a/src/tests/encryption.rs
+++ b/src/tests/encryption.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+mod tests {
+    use crate::encryption::{simple_encrypt, simple_decrypt};
+
+    #[test]
+    fn test_encrypt_decrypt_cycle() {
+        let data = b"hello world";
+        let cipher = simple_encrypt(data).expect("encrypt");
+        let plain = simple_decrypt(cipher.as_bytes()).expect("decrypt");
+        assert_eq!(plain, data);
+    }
+
+    #[test]
+    fn test_encrypt_produces_different_output() {
+        let a = simple_encrypt(b"data").expect("encrypt");
+        let b = simple_encrypt(b"data").expect("encrypt");
+        assert_ne!(a, b, "encryption should be nondeterministic");
+    }
+}

--- a/src/tests/git_action.rs
+++ b/src/tests/git_action.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use crate::git_actions::{GitAction, GitAuth, GitCredentials, GitServer};
+    use dusa_collection_utils::core::types::pathtype::PathType;
+    use dusa_collection_utils::core::types::stringy::Stringy;
+
+    #[test]
+    fn test_git_auth_url_generation() {
+        let auth = GitAuth {
+            user: Stringy::from("user"),
+            repo: Stringy::from("repo"),
+            branch: Stringy::from("main"),
+            server: GitServer::GitHub,
+            token: None,
+        };
+        let url = auth.assemble_remote_url();
+        assert!(url.contains("github.com/user/repo.git"));
+    }
+
+    #[tokio::test]
+    async fn test_bootstrap_git_credentials() {
+        let creds = GitCredentials::bootstrap_git_credentials()
+            .await
+            .expect("bootstrap");
+        assert!(creds.auth_items.is_empty());
+    }
+
+    #[test]
+    fn test_git_credentials_add() {
+        let mut creds = GitCredentials { auth_items: vec![] };
+        let auth = GitAuth {
+            user: Stringy::from("user"),
+            repo: Stringy::from("repo"),
+            branch: Stringy::from("main"),
+            server: GitServer::GitHub,
+            token: None,
+        };
+        creds.add_auth(auth.clone());
+        assert_eq!(creds.auth_items.len(), 1);
+        assert_eq!(creds.auth_items[0], auth);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_git_action_clone_mock() {
+        use tempfile::TempDir;
+        let dir = TempDir::new().unwrap();
+        let action = GitAction::Clone {
+            repo_name: Stringy::from("does_not_exist"),
+            repo_owner: Stringy::from("none"),
+            destination: PathType::PathBuf(dir.path().to_path_buf()),
+            repo_branch: Stringy::from("main"),
+            server: GitServer::GitHub,
+        };
+        // This should fail but return an error type
+        let result = action.execute().await;
+        assert!(result.is_err());
+    }
+}

--- a/src/tests/identity.rs
+++ b/src/tests/identity.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+mod tests {
+    use crate::identity::Identifier;
+
+    #[tokio::test]
+    async fn test_identifier_new_and_verify() {
+        let ident = Identifier::new().await.expect("create identifier");
+        assert!(ident.verify().await, "identifier verification failed");
+    }
+
+    #[tokio::test]
+    async fn test_identifier_json_roundtrip() {
+        let ident = Identifier::new().await.unwrap();
+        let json = ident.to_json().unwrap();
+        let decoded: Identifier = serde_json::from_str(&json).unwrap();
+        assert_eq!(ident, decoded);
+    }
+}

--- a/src/tests/network.rs
+++ b/src/tests/network.rs
@@ -1,0 +1,16 @@
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use crate::network::resolve_url;
+
+    #[tokio::test]
+    async fn test_resolve_localhost() {
+        let result = resolve_url("localhost", None).await.unwrap();
+        assert!(result.unwrap().iter().any(|ip| ip.is_loopback()));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_invalid() {
+        let result = resolve_url("invalid.invalid", None).await.unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src/tests/notification.rs
+++ b/src/tests/notification.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod tests {
+    use crate::notifications::Email;
+    use dusa_collection_utils::core::types::stringy::Stringy;
+
+    #[test]
+    fn test_email_validation() {
+        let email = Email::new(Stringy::from("sub"), Stringy::from("body"));
+        assert!(email.is_valid());
+        let invalid = Email::new(Stringy::from(""), Stringy::from(""));
+        assert!(!invalid.is_valid());
+    }
+
+    #[test]
+    fn test_email_json_roundtrip() {
+        let email = Email::new(Stringy::from("hello"), Stringy::from("world"));
+        let json = email.to_json().unwrap();
+        let parsed = Email::from_json(&json).unwrap();
+        assert_eq!(email.subject, parsed.subject);
+        assert_eq!(email.body, parsed.body);
+    }
+}

--- a/src/tests/resource_monitor.rs
+++ b/src/tests/resource_monitor.rs
@@ -1,0 +1,24 @@
+#[cfg(test)]
+mod tests {
+    use crate::resource_monitor::ResourceMonitorLock;
+    use tokio::process::Command;
+
+    #[tokio::test]
+    async fn test_resource_monitor_invalid_pid() {
+        let result = ResourceMonitorLock::new(999999);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_resource_monitor_metrics() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("1");
+        let mut child = cmd.spawn().expect("spawn");
+        let pid = child.id().expect("pid") as i32;
+
+        let monitor = ResourceMonitorLock::new(pid).expect("create monitor");
+        let metrics = monitor.get_metrics().await.expect("metrics");
+        assert!(metrics.memory_usage >= 0.0);
+        child.kill().await.expect("kill child");
+    }
+}

--- a/src/tests/state_persistence.rs
+++ b/src/tests/state_persistence.rs
@@ -1,0 +1,46 @@
+#[cfg(test)]
+mod tests {
+    use crate::aggregator::Status;
+    use crate::config::AppConfig;
+    use crate::state_persistence::{AppState, StatePersistence};
+    use dusa_collection_utils::core::version::SoftwareVersion;
+    use dusa_collection_utils::core::types::pathtype::PathType;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_save_and_load_state() {
+        let config = AppConfig::dummy();
+        let state = AppState {
+            name: "test".into(),
+            version: SoftwareVersion::dummy(),
+            data: "data".into(),
+            status: Status::Running,
+            pid: 0,
+            last_updated: 0,
+            stared_at: 0,
+            event_counter: 0,
+            error_log: vec![],
+            config,
+            system_application: false,
+            stdout: vec![],
+            stderr: vec![],
+        };
+
+        let dir = tempdir().unwrap();
+        let path: PathType = dir.path().join("state.toml").into();
+
+        StatePersistence::save_state(&state, &path)
+            .await
+            .unwrap();
+
+        let loaded = StatePersistence::load_state(&path).await.unwrap();
+        assert_eq!(state, loaded);
+    }
+
+    #[tokio::test]
+    async fn test_load_nonexistent_file() {
+        let path: PathType = "/tmp/nonexistent_state.toml".into();
+        let result = StatePersistence::load_state(&path).await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- revive old tests with updates for current API
- enable updated test modules in the library
- fix outdated doc snippets

## Testing
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68505cd4683c832d94a69d885fbf13a0